### PR TITLE
Added video tutorials page

### DIFF
--- a/addition.rst
+++ b/addition.rst
@@ -8,5 +8,6 @@
    faq
    useful
    info_wave_structure_interactions
+   tutorials
 
 `Back to FUNWAVE-TVD Page <https://fengyanshi.github.io/build/html/index.html>`_

--- a/index.rst
+++ b/index.rst
@@ -30,6 +30,8 @@ This version  features  several theoretical and numerical improvements, includin
 
 The most recent developments include ship-wake generation (`Shi et al., 2018 <https://www.sciencedirect.com/science/article/pii/S0378383917304246>`_), meteo-tsunami generation (`Woodruff et al., 2018 <https://icce-ojs-tamu.tdl.org/icce/index.php/icce/article/view/8470>`_), and sediment transport and morphological changes (`Tehranirad et al., 2016 <https://coastal.udel.edu/research-2/cacr-reports/>`_, `Malej et al., 2019 <https://apps.dtic.mil/dtic/tr/fulltext/u2/1074624.pdf>`_).
 
+|
+
 =================
 Where to start
 =================
@@ -54,6 +56,8 @@ Stay connected to the global FUNWAVE community by subscribing to the mailing gro
 .. raw:: html
    :file: google_group.html
    
+Stay up-to-date on the latest video tutorials and examples on YouTube by subscribing to `FUNWAVE Tutorials <https://www.youtube.com/channel/UCIWsla9RSOGaxoVFExGuK_w>`_ and `Fengyan Shi <https://www.youtube.com/channel/UCWmlY0Lpr8e0qnLGvlYLW1g>`_.
+
 |
 
 =============
@@ -122,6 +126,10 @@ Benefits of transitioning
 * Direct and fast link to more information (basic + extensive Wiki) without searching any printed of electronic manual/publication
 * Parameter bound and input safety checking – reduces number of initial failures
 * Larger USACE/DoD user base because of a *reduced* learning curve
+
+**NEW**
+*******
+Check out the latest video tutorial series providing an overview of the DoD HPC Portal FUNWAVE-TVD Application on the :ref:`Video Tutorials <tutorials>` page.
 
 .. note::
    The HPC Portal is accessible only to employees of USACE and the greater DoD. For more information on the HPC Portal, visit `<https://portal.hpc.mil>`_. If you currently have access to ERDC HPC systems, you can log into the ERDC HPC Portal on this webpage. Questions about getting access to the ERDC HPC Portal can be directed to Dr. Matt Malej (matt.malej@usace.army.mil).

--- a/info_wave_structure_interactions.rst
+++ b/info_wave_structure_interactions.rst
@@ -1,9 +1,9 @@
 .. _literature_interactions:
 
-**UNDER CONSTRUCTION**
-******************************
+Wave-Structure Interactions
+***************************
 
-.. Wave-Structure Interactions
+**UNDER CONSTRUCTION**
 
 
 .. Insert introductory text here

--- a/info_wave_structure_interactions.rst
+++ b/info_wave_structure_interactions.rst
@@ -1,5 +1,6 @@
 .. _literature_interactions:
 
+***************************
 Wave-Structure Interactions
 ***************************
 

--- a/tutorials.rst
+++ b/tutorials.rst
@@ -1,0 +1,39 @@
+.. _tutorials:
+
+***************
+Video Tutorials
+***************
+
+Review these "how-to" video tutorials to get started with FUNWAVE-TVD either locally or on the DoD HPC Portal.
+Subscribe to `FUNWAVE Tutorials <https://www.youtube.com/channel/UCIWsla9RSOGaxoVFExGuK_w>`_ and `Fengyan Shi <https://www.youtube.com/channel/UCWmlY0Lpr8e0qnLGvlYLW1g>`_ on YouTube to keep up-to-date on the latest videos.
+
+=======
+HOW TO
+=======
+
+Set up Linux on Windows to run FUNWAVE-TVD
+******************************************
+
+.. youtube:: TLg1XLelk6s
+
+Run FUNWAVE-TVD with Amazon Web Service
+*****************************************
+
+.. youtube:: 4Z9DJflk2vM
+
+Create movies and animations of FUNWAVE-TVD outputs with MATLAB
+***************************************************************
+
+.. youtube:: VsYB3D9_CsU
+
+
+==============
+DoD HPC Portal
+==============
+
+Introduction
+************
+
+.. youtube:: lNvsblm2afU
+
+Navigate to `FUNWAVE Tutorials <https://www.youtube.com/channel/UCIWsla9RSOGaxoVFExGuK_w>`_ on YouTube for the full tutorial series on the DoD HPC Portal Application.


### PR DESCRIPTION
@fengyanshi - new updates to include on the Wiki: Created a separate page to store/reference FUNWAVE-related video tutorials. Embedded YouTube videos on page. Created text/links to direct users to tutorials page and YouTube Channels on index. Added tutorials page under Additional Info. Updated title for wave-structures interactions page (still under construction).
@malej - tracking updates of guidance materials